### PR TITLE
US-02: Join a Game – Validate game code, join logic & error handling

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/GameSessionController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/GameSessionController.java
@@ -51,7 +51,16 @@ public class GameSessionController {
         return DTOMapper.INSTANCE.convertEntityToGameSessionGetDTO(gameSession);
     }
 
-@DeleteMapping("/game/{gameCode}")
+@PutMapping("/game/{gameCode}/join")
+    @ResponseStatus(HttpStatus.OK)
+    @ResponseBody
+    public GameSessionGetDTO joinGameSession(@PathVariable("gameCode") String gameCode, @RequestHeader("Authorization") String token) {
+        User joiner = authenticationService.authenticateByToken(token);
+        GameSession updatedGameSession = gameSessionService.joinGameSession(gameCode, joiner.getId());
+        return DTOMapper.INSTANCE.convertEntityToGameSessionGetDTO(updatedGameSession);
+    }
+
+    @DeleteMapping("/game/{gameCode}")
 @ResponseStatus(HttpStatus.NO_CONTENT)
 public void deleteGameSession(@PathVariable("gameCode") String gameCode, @RequestHeader("Authorization") String token) {
     authenticationService.authenticateByToken(token);

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/GameSessionService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/GameSessionService.java
@@ -85,6 +85,39 @@ public class GameSessionService {
 		return gameCode;
 	}
 
+	public GameSession joinGameSession(String gameCode, Long player2Id) {
+		if (gameCode == null || gameCode.length() != 6) {
+			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid game code format.");
+		}
+
+		GameSession gameSession = gameSessionRepository.findByGameCode(gameCode);
+
+		if (gameSession == null) {
+			throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Game not found or expired.");
+		}
+
+		if (gameSession.getGameStatus() != GameStatus.WAITING) {
+			throw new ResponseStatusException(HttpStatus.CONFLICT, "Game is not accepting players.");
+		}
+
+		if (gameSession.getPlayer2Id() != null) {
+			throw new ResponseStatusException(HttpStatus.CONFLICT, "Game is already full.");
+		}
+
+		if (gameSession.getPlayer1Id().equals(player2Id)) {
+			throw new ResponseStatusException(HttpStatus.CONFLICT, "You cannot join your own game.");
+		}
+
+		gameSession.setPlayer2Id(player2Id);
+		gameSession.setGameStatus(GameStatus.CONFIGURING);
+
+		gameSession = gameSessionRepository.save(gameSession);
+		gameSessionRepository.flush();
+
+		log.info("Player {} joined game session {}", player2Id, gameCode);
+		return gameSession;
+	}
+
 	public boolean deleteByGameCode(String gameCode) {
 		GameSession gameSession = gameSessionRepository.findByGameCode(gameCode);
 		if (gameSession == null) {

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/GameSessionControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/GameSessionControllerTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -254,5 +255,108 @@ public class GameSessionControllerTest {
             .andExpect(status().isBadRequest());
 
         verify(gameSessionService, never()).deleteByGameCode(Mockito.anyString());
+    }
+
+    @Test
+    public void joinGameSession_validToken_gameJoined() throws Exception {
+        // given
+        User joiner = new User();
+        joiner.setId(2L);
+        joiner.setToken("valid-token");
+
+        GameSession joinedGame = new GameSession();
+        joinedGame.setId(10L);
+        joinedGame.setGameCode("ABC123");
+        joinedGame.setGameStatus(GameStatus.CONFIGURING);
+        joinedGame.setPlayer1Id(1L);
+        joinedGame.setPlayer2Id(2L);
+        joinedGame.setActivePlayerId(1L);
+        joinedGame.setCreatedAt(LocalDateTime.of(2026, 4, 8, 10, 0));
+
+        given(authenticationService.authenticateByToken("valid-token")).willReturn(joiner);
+        given(gameSessionService.joinGameSession("ABC123", 2L)).willReturn(joinedGame);
+
+        // when
+        MockHttpServletRequestBuilder putRequest = put("/game/ABC123/join")
+            .header("Authorization", "valid-token");
+
+        // then
+        mockMvc.perform(putRequest)
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.id", is(joinedGame.getId().intValue())))
+            .andExpect(jsonPath("$.gameCode", is("ABC123")))
+            .andExpect(jsonPath("$.gameStatus", is("CONFIGURING")))
+            .andExpect(jsonPath("$.player1Id", is(1)))
+            .andExpect(jsonPath("$.player2Id", is(2)))
+            .andExpect(jsonPath("$.activePlayerId", is(1)));
+    }
+
+    @Test
+    public void joinGameSession_invalidToken_unauthorized() throws Exception {
+        // given
+        given(authenticationService.authenticateByToken("invalid-token"))
+            .willThrow(new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Invalid or expired token"));
+
+        // when
+        MockHttpServletRequestBuilder putRequest = put("/game/ABC123/join")
+            .header("Authorization", "invalid-token");
+
+        // then
+        mockMvc.perform(putRequest)
+            .andExpect(status().isUnauthorized());
+
+        verify(gameSessionService, never()).joinGameSession(Mockito.anyString(), Mockito.anyLong());
+    }
+
+    @Test
+    public void joinGameSession_missingAuthorizationHeader_badRequest() throws Exception {
+        // when
+        MockHttpServletRequestBuilder putRequest = put("/game/ABC123/join");
+
+        // then
+        mockMvc.perform(putRequest)
+            .andExpect(status().isBadRequest());
+
+        verify(gameSessionService, never()).joinGameSession(Mockito.anyString(), Mockito.anyLong());
+    }
+
+    @Test
+    public void joinGameSession_gameNotFound_notFound() throws Exception {
+        // given
+        User joiner = new User();
+        joiner.setId(2L);
+        joiner.setToken("valid-token");
+
+        given(authenticationService.authenticateByToken("valid-token")).willReturn(joiner);
+        given(gameSessionService.joinGameSession("NOTFND", 2L))
+            .willThrow(new ResponseStatusException(HttpStatus.NOT_FOUND, "Game not found or expired."));
+
+        // when
+        MockHttpServletRequestBuilder putRequest = put("/game/NOTFND/join")
+            .header("Authorization", "valid-token");
+
+        // then
+        mockMvc.perform(putRequest)
+            .andExpect(status().isNotFound());
+    }
+
+    @Test
+    public void joinGameSession_gameFull_conflict() throws Exception {
+        // given
+        User joiner = new User();
+        joiner.setId(2L);
+        joiner.setToken("valid-token");
+
+        given(authenticationService.authenticateByToken("valid-token")).willReturn(joiner);
+        given(gameSessionService.joinGameSession("ABC123", 2L))
+            .willThrow(new ResponseStatusException(HttpStatus.CONFLICT, "Game is already full."));
+
+        // when
+        MockHttpServletRequestBuilder putRequest = put("/game/ABC123/join")
+            .header("Authorization", "valid-token");
+
+        // then
+        mockMvc.perform(putRequest)
+            .andExpect(status().isConflict());
     }
 }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/GameSessionServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/GameSessionServiceTest.java
@@ -95,6 +95,93 @@ class GameSessionServiceTest {
     }
 
     @Test
+    void joinGameSession_validInput_setsPlayer2AndStatusConfiguring() {
+        GameSession existing = new GameSession();
+        existing.setId(1L);
+        existing.setGameCode("ABC123");
+        existing.setGameStatus(GameStatus.WAITING);
+        existing.setPlayer1Id(1L);
+        existing.setPlayer2Id(null);
+
+        when(gameSessionRepository.findByGameCode("ABC123")).thenReturn(existing);
+        when(gameSessionRepository.save(any(GameSession.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        GameSession result = gameSessionService.joinGameSession("ABC123", 2L);
+
+        assertEquals(2L, result.getPlayer2Id());
+        assertEquals(GameStatus.CONFIGURING, result.getGameStatus());
+        verify(gameSessionRepository, times(1)).save(any(GameSession.class));
+        verify(gameSessionRepository, times(1)).flush();
+    }
+
+    @Test
+    void joinGameSession_invalidCodeFormat_throwsBadRequest() {
+        ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+                () -> gameSessionService.joinGameSession("AB", 2L));
+        assertEquals(400, ex.getStatusCode().value());
+    }
+
+    @Test
+    void joinGameSession_nullCode_throwsBadRequest() {
+        ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+                () -> gameSessionService.joinGameSession(null, 2L));
+        assertEquals(400, ex.getStatusCode().value());
+    }
+
+    @Test
+    void joinGameSession_gameNotFound_throwsNotFound() {
+        when(gameSessionRepository.findByGameCode("NOTFND")).thenReturn(null);
+
+        ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+                () -> gameSessionService.joinGameSession("NOTFND", 2L));
+        assertEquals(404, ex.getStatusCode().value());
+    }
+
+    @Test
+    void joinGameSession_gameNotWaiting_throwsConflict() {
+        GameSession existing = new GameSession();
+        existing.setGameCode("ABC123");
+        existing.setGameStatus(GameStatus.BATTLE);
+        existing.setPlayer1Id(1L);
+
+        when(gameSessionRepository.findByGameCode("ABC123")).thenReturn(existing);
+
+        ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+                () -> gameSessionService.joinGameSession("ABC123", 2L));
+        assertEquals(409, ex.getStatusCode().value());
+    }
+
+    @Test
+    void joinGameSession_gameAlreadyFull_throwsConflict() {
+        GameSession existing = new GameSession();
+        existing.setGameCode("ABC123");
+        existing.setGameStatus(GameStatus.WAITING);
+        existing.setPlayer1Id(1L);
+        existing.setPlayer2Id(3L);
+
+        when(gameSessionRepository.findByGameCode("ABC123")).thenReturn(existing);
+
+        ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+                () -> gameSessionService.joinGameSession("ABC123", 2L));
+        assertEquals(409, ex.getStatusCode().value());
+    }
+
+    @Test
+    void joinGameSession_joiningOwnGame_throwsConflict() {
+        GameSession existing = new GameSession();
+        existing.setGameCode("ABC123");
+        existing.setGameStatus(GameStatus.WAITING);
+        existing.setPlayer1Id(1L);
+        existing.setPlayer2Id(null);
+
+        when(gameSessionRepository.findByGameCode("ABC123")).thenReturn(existing);
+
+        ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+                () -> gameSessionService.joinGameSession("ABC123", 1L));
+        assertEquals(409, ex.getStatusCode().value());
+    }
+
+    @Test
     void cleanupExpiredGameSessions_withNoExpiredSessions_doesNotDeleteAnything() {
         when(gameSessionRepository.findByPlayer2IdIsNullAndCreatedAtBefore(any(LocalDateTime.class)))
                 .thenReturn(Collections.emptyList());


### PR DESCRIPTION
## Summary
Implements the backend for US-02 (Join a Game).

## Changes
- `PUT /game/{gameCode}/join` endpoint — authenticates via token, returns updated `GameSessionGetDTO`
- Join logic in `GameSessionService.joinGameSession()`:
  - Validates game code is 6 characters → 400
  - Looks up game by code → 404 if not found
  - Rejects if game not in `WAITING` status → 409
  - Rejects if game already has 2 players → 409
  - Rejects if player tries to join their own game → 409
  - Sets `player2Id`, transitions status to `CONFIGURING`

## Closes
Closes #30, Closes #31