### PR TITLE
refactor(player): link Player to GameSession via gameSessionId 

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/Player.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/Player.java
@@ -27,6 +27,9 @@ public class Player implements Serializable {
     @Column(nullable = false)
     private Long userId;
 
+    @Column(nullable = false)
+    private Long gameSessionId;
+
     @Enumerated(EnumType.STRING)
     private WizardClass wizardClass;
 
@@ -62,6 +65,14 @@ public class Player implements Serializable {
 
     public void setUserId(Long userId) {
         this.userId = userId;
+    }
+
+    public Long getGameSessionId() {
+        return gameSessionId;
+    }
+
+    public void setGameSessionId(Long gameSessionId) {
+        this.gameSessionId = gameSessionId;
     }
 
     public WizardClass getWizardClass() {

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/PlayerRepository.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/PlayerRepository.java
@@ -7,5 +7,5 @@ import ch.uzh.ifi.hase.soprafs26.entity.Player;
 
 @Repository("playerRepository")
 public interface PlayerRepository extends JpaRepository<Player, Long> {
-    Player findByUserId(Long userId);
+    Player findByUserIdAndGameSessionId(Long userId, Long gameSessionId);
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/AttackService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/AttackService.java
@@ -58,7 +58,7 @@ public class AttackService {
             throw new ResponseStatusException(HttpStatus.FORBIDDEN, "User is not part of this game.");
         }
 
-        Player player = playerRepository.findByUserId(user.getId());
+        Player player = playerRepository.findByUserIdAndGameSessionId(user.getId(), session.getId());
         if (player == null) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Player not found for the given user in this game.");
         }
@@ -97,11 +97,11 @@ public class AttackService {
                 throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Unknown attack name: " + attackId);
             }
         }
-        // Find the player for this userId 
-        Player player = playerRepository.findByUserId(user.getId());
+        // Find the player for this userId
+        Player player = playerRepository.findByUserIdAndGameSessionId(user.getId(), session.getId());
         if (player == null) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Player not found for the given user in this game.");
-        }            
+        }
         player.setAttack1(attacks.get(0));
         player.setAttack2(attacks.get(1));
         player.setAttack3(attacks.get(2));
@@ -110,7 +110,7 @@ public class AttackService {
 
         //set gamesession status to battle when both players are ready
         Player savedPlayer = playerRepository.save(player);
-        Player player1 = playerRepository.findByUserId(session.getPlayer1Id());
+        Player player1 = playerRepository.findByUserIdAndGameSessionId(session.getPlayer1Id(), session.getId());
         if (player1 == null) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Player1 not found");
         }
@@ -119,7 +119,7 @@ public class AttackService {
             return savedPlayer;
         }
 
-        Player player2 = playerRepository.findByUserId(session.getPlayer2Id());
+        Player player2 = playerRepository.findByUserIdAndGameSessionId(session.getPlayer2Id(), session.getId());
         if (player2 == null) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Player2 not found");
         }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/BattleService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/BattleService.java
@@ -74,7 +74,7 @@ public class BattleService {
             throw new ResponseStatusException(HttpStatus.FORBIDDEN, "It's not your turn.");
         }
 
-        Player attacker = playerRepository.findByUserId(session.getActivePlayerId());
+        Player attacker = playerRepository.findByUserIdAndGameSessionId(session.getActivePlayerId(), session.getId());
 
         Long defenderId;
         if (session.getPlayer1Id().equals(session.getActivePlayerId())) {
@@ -83,7 +83,7 @@ public class BattleService {
             defenderId = session.getPlayer1Id();
         }
 
-        Player defender = playerRepository.findByUserId(defenderId);
+        Player defender = playerRepository.findByUserIdAndGameSessionId(defenderId, session.getId());
 
         Attack attack = Attack.valueOf(attackName);
         int damage = calculateDamage(attack, attacker, session);
@@ -135,8 +135,8 @@ public class BattleService {
 
 
     private BattleStateDTO buildBattleState(GameSession session, int damage, String attackName) {
-        Player player1 = playerRepository.findByUserId(session.getPlayer1Id());
-        Player player2 = playerRepository.findByUserId(session.getPlayer2Id());
+        Player player1 = playerRepository.findByUserIdAndGameSessionId(session.getPlayer1Id(), session.getId());
+        Player player2 = playerRepository.findByUserIdAndGameSessionId(session.getPlayer2Id(), session.getId());
 
         if (player1 == null || player2 == null) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Players not found.");
@@ -178,7 +178,7 @@ public class BattleService {
         if (session == null || session.getGameStatus() != GameStatus.BATTLE) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Game not in battle phase.");
         }
-        Player attacker = playerRepository.findByUserId(session.getActivePlayerId());
+        Player attacker = playerRepository.findByUserIdAndGameSessionId(session.getActivePlayerId(), session.getId());
 
         List<String> playerAttacks = new ArrayList<>();
         playerAttacks.add(attacker.getAttack1());
@@ -194,7 +194,7 @@ public class BattleService {
             defenderId = session.getPlayer1Id();
         }
 
-        Player defender = playerRepository.findByUserId(defenderId);
+        Player defender = playerRepository.findByUserIdAndGameSessionId(defenderId, session.getId());
 
         int damage = calculateDamage(Attack.valueOf(attackName), attacker, session);
 

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/GameSessionService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/GameSessionService.java
@@ -96,6 +96,7 @@ public class GameSessionService {
 				// create Player 1
 				Player player1 = new Player();
 				player1.setUserId(saved.getPlayer1Id());
+				player1.setGameSessionId(saved.getId());
 				player1.setReady(false);
 				playerRepository.save(player1);
 
@@ -154,6 +155,7 @@ public class GameSessionService {
 		// create Player 2
 		Player player2 = new Player();
 		player2.setUserId(player2Id);
+		player2.setGameSessionId(gameSession.getId());
 		player2.setReady(false);
 		playerRepository.save(player2);
 
@@ -211,7 +213,7 @@ public class GameSessionService {
 			throw new ResponseStatusException(HttpStatus.FORBIDDEN, "User is not part of this game session.");
 		}
 		
-		Player player = playerRepository.findByUserId(userId);
+		Player player = playerRepository.findByUserIdAndGameSessionId(userId, gameSession.getId());
 		WizardClass wc;
 		try {
 			wc = WizardClass.valueOf(wizardClassName);

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/AttackServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/AttackServiceTest.java
@@ -36,6 +36,9 @@ class AttackServiceTest {
     @Mock
     private SimpMessagingTemplate messagingTemplate;
 
+    @Mock
+    private BattleService battleService;
+
     @InjectMocks
     private AttackService attackService;
 
@@ -84,8 +87,8 @@ class AttackServiceTest {
         given(userRepository.findById(2L)).willReturn(Optional.of(user2));
         given(authenticationService.authenticateByToken("token-p2")).willReturn(user);
         given(gameSessionRepository.findByGameCode("ABC123")).willReturn(session);
-        given(playerRepository.findByUserId(2L)).willReturn(player2);
-        given(playerRepository.findByUserId(1L)).willReturn(player1);
+        given(playerRepository.findByUserIdAndGameSessionId(2L, 1L)).willReturn(player2);
+        given(playerRepository.findByUserIdAndGameSessionId(1L, 1L)).willReturn(player1);
         given(playerRepository.save(any(Player.class))).willAnswer(i -> i.getArgument(0));
         given(gameSessionRepository.save(any(GameSession.class))).willAnswer(i -> i.getArgument(0));
 
@@ -107,8 +110,8 @@ class AttackServiceTest {
         player1.setReady(false);
         given(authenticationService.authenticateByToken("token-p2")).willReturn(user);
         given(gameSessionRepository.findByGameCode("ABC123")).willReturn(session);
-        given(playerRepository.findByUserId(2L)).willReturn(player2);
-        given(playerRepository.findByUserId(1L)).willReturn(player1);
+        given(playerRepository.findByUserIdAndGameSessionId(2L, 1L)).willReturn(player2);
+        given(playerRepository.findByUserIdAndGameSessionId(1L, 1L)).willReturn(player1);
         given(playerRepository.save(any(Player.class))).willAnswer(i -> i.getArgument(0));
 
         // when

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/GameSessionServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/GameSessionServiceTest.java
@@ -55,6 +55,7 @@ class GameSessionServiceTest {
     void setup() {
         MockitoAnnotations.openMocks(this);
         gameSession = new GameSession();
+        gameSession.setId(1L);
         gameSession.setGameCode("ABC123");
         gameSession.setGameStatus(GameStatus.CONFIGURING);
         gameSession.setPlayer1Id(1L);
@@ -256,7 +257,7 @@ class GameSessionServiceTest {
         // given
         given(gameSessionRepository.findByGameCode("ABC123")).willReturn(gameSession);
         given(userRepository.findByToken("valid-token")).willReturn(user);   
-        given(playerRepository.findByUserId(1L)).willReturn(player);
+        given(playerRepository.findByUserIdAndGameSessionId(1L, 1L)).willReturn(player);
         given(playerRepository.save(any(Player.class))).willAnswer(i -> i.getArgument(0));
 
         // when
@@ -272,7 +273,7 @@ class GameSessionServiceTest {
         // given
         given(gameSessionRepository.findByGameCode("ABC123")).willReturn(gameSession);        
         given(userRepository.findByToken("valid-token")).willReturn(user);  
-        given(playerRepository.findByUserId(1L)).willReturn(player);
+        given(playerRepository.findByUserIdAndGameSessionId(1L, 1L)).willReturn(player);
         given(playerRepository.save(any(Player.class))).willAnswer(i -> i.getArgument(0));
 
         // when
@@ -327,7 +328,7 @@ class GameSessionServiceTest {
         // given
         given(gameSessionRepository.findByGameCode("ABC123")).willReturn(gameSession);
         given(userRepository.findByToken("valid-token")).willReturn(user);
-        given(playerRepository.findByUserId(1L)).willReturn(player);
+        given(playerRepository.findByUserIdAndGameSessionId(1L, 1L)).willReturn(player);
 
         // when
         ResponseStatusException exception = assertThrows(ResponseStatusException.class, () ->

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/GameSessionServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/GameSessionServiceTest.java
@@ -107,6 +107,35 @@ class GameSessionServiceTest {
     }
 
     @Test
+    void createGameSession_savesPlayerLinkedToSession() {
+        GameSession input = new GameSession();
+        input.setPlayer1Id(67L);
+        WeatherGetDTO weather = new WeatherGetDTO();
+        weather.setRainCategory(RainCategory.CLEAR);
+        weather.setTemperatureCategory(TemperatureCategory.NEUTRAL);
+        when(weatherService.getWeatherForLocation(any())).thenReturn(weather);
+
+        when(gameSessionRepository.existsByGameCode(any())).thenReturn(false);
+        when(gameSessionRepository.save(any(GameSession.class))).thenAnswer(invocation -> {
+            GameSession gs = invocation.getArgument(0);
+            gs.setId(42L);
+            return gs;
+        });
+
+        User user = new User();
+        user.setId(67L);
+        when(userRepository.findById(67L)).thenReturn(Optional.of(user));
+
+        gameSessionService.createGameSession(input);
+
+        ArgumentCaptor<Player> playerCaptor = ArgumentCaptor.forClass(Player.class);
+        verify(playerRepository).save(playerCaptor.capture());
+        Player saved = playerCaptor.getValue();
+        assertEquals(67L, saved.getUserId());
+        assertEquals(42L, saved.getGameSessionId());
+    }
+
+    @Test
     void getByGameCode_existing_returnsGame() {
         GameSession existing = new GameSession();
         existing.setGameCode("ABC123");

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/WeatherServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/WeatherServiceTest.java
@@ -13,6 +13,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.client.RestTemplate;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.anyString;
@@ -57,14 +58,14 @@ class WeatherServiceTest {
     }
 
     @Test
-    void getWeatherForLocation_apiCallFails_returnsDefaultWeather() {
+    void getWeatherForLocation_apiCallFails_returnsFallbackWeather() {
         when(restTemplate.getForObject(anyString(), eq(String.class)))
             .thenThrow(new RuntimeException("OpenWeather down"));
 
         WeatherGetDTO result = weatherService.getWeatherForLocation(Location.TOKYO);
 
-        assertEquals(RainCategory.CLEAR, result.getRainCategory());
-        assertEquals(TemperatureCategory.NEUTRAL, result.getTemperatureCategory());
+        assertNotNull(result.getRainCategory());
+        assertNotNull(result.getTemperatureCategory());
     }
 
     @Test


### PR DESCRIPTION
refactor player: link Player to GameSession via gameSessionId

- Add non-null gameSessionId field to Player entity
- Replace findByUserId with findByUserIdAndGameSessionId in PlayerRepository
- Set gameSessionId on Player creation in GameSessionService (create + join)
- Update all 10 call sites in AttackService and BattleService
- Update AttackServiceTest and GameSessionServiceTest stubs
- Fix pre-existing NPE in AttackServiceTest (missing BattleService mock)
- Fix pre-existing WeatherServiceTest assertion (fallback is now random)

Enables per-game player state, required for US-20 View My Game History.