### PR TITLE
app.yaml: add manual_scaling to fix cross-instance token loss

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -4,5 +4,8 @@
 runtime: java17
 instance_class: F2
 
+manual_scaling:
+  instances: 1
+
 env_variables:
   OPENWEATHER_API_KEY: ${OPENWEATHER_API_KEY}


### PR DESCRIPTION
- Add manual_scaling: instances: 1 to app.yaml so all requests land on the same JVM.
- Fixes intermittent 401 "Invalid token" on /games/{code}/join (and other authenticated endpoints) after a successful login.
