### PR TITLE
US03 Join a random match

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/MatchMakingController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/MatchMakingController.java
@@ -3,7 +3,9 @@ package ch.uzh.ifi.hase.soprafs26.controller;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import ch.uzh.ifi.hase.soprafs26.service.MatchMakingService;
+import ch.uzh.ifi.hase.soprafs26.entity.User;
 import ch.uzh.ifi.hase.soprafs26.service.AuthenticationService;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -33,5 +35,18 @@ public class MatchMakingController {
     public void joinRandomGameSession(@RequestHeader("Authorization") String token) {
         Long userId = authenticationService.authenticateByToken(token).getId();
         matchMakingService.joinRandomGameSession(userId);
+    }
+
+    @DeleteMapping("/matchmaking/leave")
+    @ResponseStatus(HttpStatus.OK)
+    @ResponseBody
+    @Operation(summary = "Leave a waiting game session", description = "Leaves a waiting game session for the authenticated user")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "Game session left successfully"),
+        @ApiResponse(responseCode = "401", description = "Unauthorized - invalid or missing token")
+    })
+    public void leaveGameSession(@RequestHeader("Authorization") String token) {
+        Long userId = authenticationService.authenticateByToken(token).getId();
+        matchMakingService.leaveGameSession(userId);
     }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/MatchMakingController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/MatchMakingController.java
@@ -5,7 +5,6 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import ch.uzh.ifi.hase.soprafs26.service.MatchMakingService;
-import ch.uzh.ifi.hase.soprafs26.entity.User;
 import ch.uzh.ifi.hase.soprafs26.service.AuthenticationService;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ResponseStatus;

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/MatchMakingController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/MatchMakingController.java
@@ -1,0 +1,37 @@
+package ch.uzh.ifi.hase.soprafs26.controller;
+
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RestController;
+import ch.uzh.ifi.hase.soprafs26.service.MatchMakingService;
+import ch.uzh.ifi.hase.soprafs26.service.AuthenticationService;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.ResponseBody;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+
+@RestController
+public class MatchMakingController {
+    
+    private final MatchMakingService matchMakingService;
+    private final AuthenticationService authenticationService;
+    public MatchMakingController(MatchMakingService matchMakingService, AuthenticationService authenticationService) {
+        this.matchMakingService = matchMakingService;
+        this.authenticationService = authenticationService;
+    }
+
+    @PostMapping("/matchmaking/join")
+    @ResponseStatus(HttpStatus.OK)
+    @ResponseBody
+    @Operation(summary = "Join a random game session", description = "Joins a random game session for the authenticated user")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "Game session joined successfully"),
+        @ApiResponse(responseCode = "401", description = "Unauthorized - invalid or missing token")
+    })
+    public void joinRandomGameSession(@RequestHeader("Authorization") String token) {
+        Long userId = authenticationService.authenticateByToken(token).getId();
+        matchMakingService.joinRandomGameSession(userId);
+    }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/MatchMaking.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/MatchMaking.java
@@ -1,0 +1,60 @@
+package ch.uzh.ifi.hase.soprafs26.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.MapsId;
+import java.time.LocalDateTime;
+import java.io.Serializable;
+
+@Entity
+@Table(name = "match_making")
+public class MatchMaking implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    @Id
+    private Long id;
+
+    @OneToOne
+    @MapsId
+    private User user; 
+
+    private LocalDateTime joinedAt; 
+
+    private String matchedGameCode; 
+    
+
+
+public Long getId() {
+    return id;
+}
+
+public void setId(Long id) {
+    this.id = id;
+}
+
+public User getUser() {
+    return user;
+}   
+
+public void setUser(User user) {
+    this.user = user;
+}
+
+public LocalDateTime getJoinedAt() {
+    return joinedAt;
+}
+
+public void setJoinedAt(LocalDateTime joinedAt) {
+    this.joinedAt = joinedAt;
+}
+
+public String getMatchedGameCode() {
+    return matchedGameCode;
+}
+
+public void setMatchedGameCode(String matchedGameCode) {
+    this.matchedGameCode = matchedGameCode;
+}
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/MatchMakingRepository.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/MatchMakingRepository.java
@@ -6,6 +6,7 @@ import ch.uzh.ifi.hase.soprafs26.entity.MatchMaking;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import java.util.Optional;
+import java.time.LocalDateTime;
 
 
 
@@ -14,4 +15,5 @@ public interface MatchMakingRepository extends JpaRepository<MatchMaking, Long> 
 
     @Query("SELECT m FROM MatchMaking m WHERE m.id != :userId AND m.matchedGameCode IS NULL ORDER BY m.joinedAt ASC")
     Optional<MatchMaking> findFirstByIdNotAndMatchedGameCodeIsNullOrderByJoinedAtAsc(@Param("userId") Long userId);
+    void deleteByJoinedAtBeforeAndMatchedGameCodeIsNull(LocalDateTime joinedAt);
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/MatchMakingRepository.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/MatchMakingRepository.java
@@ -12,6 +12,6 @@ import java.util.Optional;
 @Repository("matchMakingRepository")
 public interface MatchMakingRepository extends JpaRepository<MatchMaking, Long> {
 
-    @Query("SELECT m FROM MatchMaking m WHERE m.id != :userId AND m.matchedGameId IS NULL ORDER BY m.joinedAt ASC")
-    Optional<MatchMaking> findFirstByIdNotAndMatchedGameIdIsNullOrderByJoinedAtAsc(@Param("Id") Long Id);
+    @Query("SELECT m FROM MatchMaking m WHERE m.id != :userId AND m.matchedGameCode IS NULL ORDER BY m.joinedAt ASC")
+    Optional<MatchMaking> findFirstByIdNotAndMatchedGameCodeIsNullOrderByJoinedAtAsc(@Param("userId") Long userId);
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/MatchMakingRepository.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/MatchMakingRepository.java
@@ -1,0 +1,17 @@
+package ch.uzh.ifi.hase.soprafs26.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import ch.uzh.ifi.hase.soprafs26.entity.MatchMaking;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import java.util.Optional;
+
+
+
+@Repository("matchMakingRepository")
+public interface MatchMakingRepository extends JpaRepository<MatchMaking, Long> {
+
+    @Query("SELECT m FROM MatchMaking m WHERE m.id != :userId AND m.matchedGameId IS NULL ORDER BY m.joinedAt ASC")
+    Optional<MatchMaking> findFirstByIdNotAndMatchedGameIdIsNullOrderByJoinedAtAsc(@Param("Id") Long Id);
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/GameSessionService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/GameSessionService.java
@@ -115,6 +115,9 @@ public class GameSessionService {
 					}
 					user2.setCurrentGameSessionId(saved.getId());
 					userRepository.save(user2);
+					saved.setGameStatus(GameStatus.CONFIGURING);
+					gameSessionRepository.save(saved);
+
 				}
 
 				User user = userRepository.findById(saved.getPlayer1Id())

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/GameSessionService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/GameSessionService.java
@@ -102,6 +102,21 @@ public class GameSessionService {
 				player1.setReady(false);
 				playerRepository.save(player1);
 
+				if (saved.getPlayer2Id() != null) {
+					Player player2 = new Player();
+					player2.setUserId(saved.getPlayer2Id());
+					player2.setGameSessionId(saved.getId());
+					player2.setReady(false);
+					playerRepository.save(player2);
+					User user2 = userRepository.findById(saved.getPlayer2Id())
+						.orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found"));
+					if (user2.getCurrentGameSessionId() != null) {
+						throw new ResponseStatusException(HttpStatus.CONFLICT, "User already is in a game session.");
+					}
+					user2.setCurrentGameSessionId(saved.getId());
+					userRepository.save(user2);
+				}
+
 				User user = userRepository.findById(saved.getPlayer1Id())
                 	.orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found"));
 				if (user.getCurrentGameSessionId() != null) {
@@ -109,6 +124,8 @@ public class GameSessionService {
 				}
             	user.setCurrentGameSessionId(saved.getId()); 
                 userRepository.save(user); 
+				
+
 
 				return saved;
 			} catch (DataIntegrityViolationException e) {

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/MatchMakingService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/MatchMakingService.java
@@ -11,10 +11,10 @@ import org.springframework.web.server.ResponseStatusException;
 import java.time.LocalDateTime;
 import java.util.Optional;
 import ch.uzh.ifi.hase.soprafs26.entity.GameSession;
-import ch.uzh.ifi.hase.soprafs26.constant.GameStatus;
 import ch.uzh.ifi.hase.soprafs26.repository.GameSessionRepository;
-import ch.uzh.ifi.hase.soprafs26.entity.User;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import ch.uzh.ifi.hase.soprafs26.service.GameSessionService;
 
 
 @Service
@@ -25,11 +25,13 @@ public class MatchMakingService {
     private final UserRepository userRepository;
     private final GameSessionRepository gameSessionRepository;  
     private final SimpMessagingTemplate messagingTemplate;
-    public MatchMakingService(MatchMakingRepository matchMakingRepository, UserRepository userRepository, GameSessionRepository gameSessionRepository, SimpMessagingTemplate messagingTemplate) {
+    private final GameSessionService gameSessionService;
+    public MatchMakingService(MatchMakingRepository matchMakingRepository, UserRepository userRepository, GameSessionRepository gameSessionRepository, SimpMessagingTemplate messagingTemplate, GameSessionService gameSessionService) {
         this.matchMakingRepository = matchMakingRepository;
         this.userRepository = userRepository;
         this.gameSessionRepository = gameSessionRepository;
         this.messagingTemplate = messagingTemplate;
+        this.gameSessionService = gameSessionService;
     }
 
 
@@ -79,14 +81,15 @@ public class MatchMakingService {
     }
 
     private GameSession createGameSession(Long userId1, Long userId2) {
-        GameSession gameSession = new GameSession();
-        gameSession.setPlayer1Id(userId1);
-        gameSession.setPlayer2Id(userId2);
-        gameSession.setGameCode("ABC123");
-        gameSession.setGameStatus(GameStatus.WAITING);
-        gameSession.setCreatedAt(LocalDateTime.now());
-        return gameSessionRepository.save(gameSession);
+        GameSession newGameSession = new GameSession();
+        newGameSession.setPlayer1Id(userId1);
+        newGameSession.setPlayer2Id(userId2);
+        return gameSessionService.createGameSession(newGameSession);
     }
 
-    
+    @Scheduled(fixedDelay = 5000) 
+    public void purgeExpiredEntries() {
+        LocalDateTime cutoff = LocalDateTime.now().minusSeconds(60);
+        matchMakingRepository.deleteByJoinedAtBeforeAndMatchedGameCodeIsNull(cutoff);
+    }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/MatchMakingService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/MatchMakingService.java
@@ -46,8 +46,8 @@ public class MatchMakingService {
             matchMakingRepository.save(myEntry);
             matchMakingRepository.save(opponent);
 
-            messagingTemplate.convertAndSend("/topic/match/" + userId, gameSession.getId());
-            messagingTemplate.convertAndSend("/topic/match/" + opponent.getId(), gameSession.getId());
+            messagingTemplate.convertAndSend("/topic/match/" + userId, gameSession.getGameCode());
+            messagingTemplate.convertAndSend("/topic/match/" + opponent.getId(), gameSession.getGameCode());
 
             matchMakingRepository.delete(myEntry);
             matchMakingRepository.delete(opponent);

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/MatchMakingService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/MatchMakingService.java
@@ -92,4 +92,11 @@ public class MatchMakingService {
         LocalDateTime cutoff = LocalDateTime.now().minusSeconds(60);
         matchMakingRepository.deleteByJoinedAtBeforeAndMatchedGameCodeIsNull(cutoff);
     }
+
+    public void leaveGameSession(Long userId) {
+        MatchMaking myEntry = matchMakingRepository.findById(userId)
+            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found"));
+        matchMakingRepository.delete(myEntry);
+        return;
+    }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/MatchMakingService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/MatchMakingService.java
@@ -1,0 +1,91 @@
+package ch.uzh.ifi.hase.soprafs26.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import ch.uzh.ifi.hase.soprafs26.repository.MatchMakingRepository;
+import ch.uzh.ifi.hase.soprafs26.repository.UserRepository;
+import ch.uzh.ifi.hase.soprafs26.entity.MatchMaking;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import ch.uzh.ifi.hase.soprafs26.entity.GameSession;
+import ch.uzh.ifi.hase.soprafs26.constant.GameStatus;
+import ch.uzh.ifi.hase.soprafs26.repository.GameSessionRepository;
+import ch.uzh.ifi.hase.soprafs26.entity.User;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+
+
+@Service
+@Transactional
+public class MatchMakingService {
+
+    private final MatchMakingRepository matchMakingRepository;
+    private final UserRepository userRepository;
+    private final GameSessionRepository gameSessionRepository;  
+    private final SimpMessagingTemplate messagingTemplate;
+    public MatchMakingService(MatchMakingRepository matchMakingRepository, UserRepository userRepository, GameSessionRepository gameSessionRepository, SimpMessagingTemplate messagingTemplate) {
+        this.matchMakingRepository = matchMakingRepository;
+        this.userRepository = userRepository;
+        this.gameSessionRepository = gameSessionRepository;
+        this.messagingTemplate = messagingTemplate;
+    }
+
+
+    public void joinRandomGameSession(Long userId) {
+        MatchMaking myEntry =join(userId);
+
+        MatchMaking opponent = searchOpponent(userId);
+        if (opponent != null) {
+            GameSession gameSession = createGameSession(userId, opponent.getId());
+            myEntry.setMatchedGameCode(gameSession.getGameCode()); 
+            opponent.setMatchedGameCode(gameSession.getGameCode());
+            matchMakingRepository.save(myEntry);
+            matchMakingRepository.save(opponent);
+
+            messagingTemplate.convertAndSend("/topic/match/" + userId, gameSession.getId());
+            messagingTemplate.convertAndSend("/topic/match/" + opponent.getId(), gameSession.getId());
+
+            matchMakingRepository.delete(myEntry);
+            matchMakingRepository.delete(opponent);
+        }
+    }
+
+
+    private MatchMaking join(Long userId) {
+        Optional<MatchMaking> existingEntry = matchMakingRepository.findById(userId);
+        if (existingEntry.isPresent()) {
+            existingEntry.get().setJoinedAt(LocalDateTime.now());
+            return matchMakingRepository.save(existingEntry.get());
+        }
+
+        MatchMaking matchMaking = new MatchMaking();
+        matchMaking.setId(userId);
+        matchMaking.setUser(userRepository.findById(userId)
+            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found")));
+        matchMaking.setJoinedAt(LocalDateTime.now());
+        matchMaking.setMatchedGameCode(null);
+        return matchMakingRepository.save(matchMaking);
+    }
+
+    private MatchMaking searchOpponent(Long userId) {
+        Optional<MatchMaking> opponent = matchMakingRepository.findFirstByIdNotAndMatchedGameIdIsNullOrderByJoinedAtAsc(userId);
+        if (opponent.isPresent()) {
+            return opponent.get();
+        }
+        return null;
+    }
+
+    private GameSession createGameSession(Long userId1, Long userId2) {
+        GameSession gameSession = new GameSession();
+        gameSession.setPlayer1Id(userId1);
+        gameSession.setPlayer2Id(userId2);
+        gameSession.setGameCode("ABC123");
+        gameSession.setGameStatus(GameStatus.WAITING);
+        gameSession.setCreatedAt(LocalDateTime.now());
+        return gameSessionRepository.save(gameSession);
+    }
+
+    
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/MatchMakingService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/MatchMakingService.java
@@ -50,6 +50,7 @@ public class MatchMakingService {
             matchMakingRepository.delete(myEntry);
             matchMakingRepository.delete(opponent);
         }
+        return;
     }
 
 
@@ -70,7 +71,7 @@ public class MatchMakingService {
     }
 
     private MatchMaking searchOpponent(Long userId) {
-        Optional<MatchMaking> opponent = matchMakingRepository.findFirstByIdNotAndMatchedGameIdIsNullOrderByJoinedAtAsc(userId);
+        Optional<MatchMaking> opponent = matchMakingRepository.findFirstByIdNotAndMatchedGameCodeIsNullOrderByJoinedAtAsc(userId);
         if (opponent.isPresent()) {
             return opponent.get();
         }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/MatchMakingControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/MatchMakingControllerTest.java
@@ -1,0 +1,112 @@
+package ch.uzh.ifi.hase.soprafs26.controller;
+
+import ch.uzh.ifi.hase.soprafs26.entity.User;
+import ch.uzh.ifi.hase.soprafs26.service.AuthenticationService;
+import ch.uzh.ifi.hase.soprafs26.service.MatchMakingService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.*;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.server.ResponseStatusException;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class MatchMakingControllerTest {
+
+    @Mock
+    private MatchMakingService matchMakingService;
+
+    @Mock
+    private AuthenticationService authenticationService;
+
+    @InjectMocks
+    private MatchMakingController matchMakingController;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        matchMakingController = new MatchMakingController(matchMakingService, authenticationService);
+        mockMvc = MockMvcBuilders.standaloneSetup(matchMakingController).build();
+    }
+
+    @Test
+    void joinRandomGameSession_ReturnsOk_IfAuthenticated() throws Exception {
+        // given
+        String token = "validToken";
+        Long userId = 99L;
+        User user = new User();
+        user.setId(userId);
+
+        when(authenticationService.authenticateByToken(token)).thenReturn(user);
+
+        // when/then
+        mockMvc.perform(post("/matchmaking/join")
+                .header("Authorization", token)
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+
+        verify(authenticationService, times(1)).authenticateByToken(token);
+        verify(matchMakingService, times(1)).joinRandomGameSession(userId);
+    }
+
+    @Test
+    void joinRandomGameSession_Returns401_IfNotAuthenticated() throws Exception {
+        // given
+        String token = "invalidToken";
+        when(authenticationService.authenticateByToken(token)).thenThrow(new ResponseStatusException(org.springframework.http.HttpStatus.UNAUTHORIZED));
+
+        // when/then
+        mockMvc.perform(post("/matchmaking/join")
+                .header("Authorization", token)
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isUnauthorized());
+
+        verify(authenticationService, times(1)).authenticateByToken(token);
+        verify(matchMakingService, never()).joinRandomGameSession(any());
+    }
+
+    @Test
+    void leaveGameSession_ReturnsOk_IfAuthenticated() throws Exception {
+        // given
+        String token = "someToken";
+        Long userId = 23L;
+        User user = new User();
+        user.setId(userId);
+
+        when(authenticationService.authenticateByToken(token)).thenReturn(user);
+
+        // when/then
+        mockMvc.perform(delete("/matchmaking/leave")
+                .header("Authorization", token)
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+
+        verify(authenticationService, times(1)).authenticateByToken(token);
+        verify(matchMakingService, times(1)).leaveGameSession(userId);
+    }
+
+    @Test
+    void leaveGameSession_Returns401_IfNotAuthenticated() throws Exception {
+        // given
+        String token = "badToken";
+        when(authenticationService.authenticateByToken(token)).thenThrow(new ResponseStatusException(org.springframework.http.HttpStatus.UNAUTHORIZED));
+
+        // when/then
+        mockMvc.perform(delete("/matchmaking/leave")
+                .header("Authorization", token)
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isUnauthorized());
+
+        verify(authenticationService, times(1)).authenticateByToken(token);
+        verify(matchMakingService, never()).leaveGameSession(any());
+    }
+}
+

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/MatchMakingServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/MatchMakingServiceTest.java
@@ -8,14 +8,12 @@ import ch.uzh.ifi.hase.soprafs26.repository.MatchMakingRepository;
 import ch.uzh.ifi.hase.soprafs26.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.springframework.http.HttpStatus;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.web.server.ResponseStatusException;
-import org.springframework.messaging.simp.SimpMessagingTemplate;
 
 import java.time.LocalDateTime;
 import java.util.Optional;
@@ -108,8 +106,8 @@ class MatchMakingServiceTest {
         verify(matchMakingRepository, atLeastOnce()).save(any(MatchMaking.class));
         verify(matchMakingRepository, times(1)).delete(myEntry);
         verify(matchMakingRepository, times(1)).delete(opponentEntry);
-        verify(simpleMessagingTemplate, times(1)).convertAndSend("/topic/match/" + userId, gameSession.getId());
-        verify(simpleMessagingTemplate, times(1)).convertAndSend("/topic/match/" + opponentId, gameSession.getId());
+        verify(simpleMessagingTemplate, times(1)).convertAndSend("/topic/match/" + userId, gameSession.getGameCode());
+        verify(simpleMessagingTemplate, times(1)).convertAndSend("/topic/match/" + opponentId, gameSession.getGameCode());
         assertThat(myEntry.getMatchedGameCode()).isEqualTo(gameSession.getGameCode());
         assertThat(opponentEntry.getMatchedGameCode()).isEqualTo(gameSession.getGameCode());
     }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/MatchMakingServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/MatchMakingServiceTest.java
@@ -1,0 +1,177 @@
+package ch.uzh.ifi.hase.soprafs26.service;
+
+import ch.uzh.ifi.hase.soprafs26.entity.GameSession;
+import ch.uzh.ifi.hase.soprafs26.entity.MatchMaking;
+import ch.uzh.ifi.hase.soprafs26.entity.User;
+import ch.uzh.ifi.hase.soprafs26.repository.GameSessionRepository;
+import ch.uzh.ifi.hase.soprafs26.repository.MatchMakingRepository;
+import ch.uzh.ifi.hase.soprafs26.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.HttpStatus;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+class MatchMakingServiceTest {
+
+    @Mock
+    private MatchMakingRepository matchMakingRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private GameSessionRepository gameSessionRepository;
+
+    @Mock
+    private SimpMessagingTemplate simpleMessagingTemplate;
+
+    @Mock
+    private GameSessionService gameSessionService;
+
+    @InjectMocks
+    private MatchMakingService matchMakingService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        matchMakingService = new MatchMakingService(matchMakingRepository, userRepository, gameSessionRepository, simpleMessagingTemplate, gameSessionService);
+    }
+
+    @Test
+    void joinRandomGameSession_CreatesAndJoins_WhenNoOpponent() {
+        // given
+        Long userId = 1L;
+        MatchMaking entry = new MatchMaking();
+        entry.setId(userId);
+
+        when(matchMakingRepository.findById(userId)).thenReturn(Optional.empty());
+        User user = new User();
+        user.setId(userId);
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(matchMakingRepository.save(any(MatchMaking.class))).thenReturn(entry);
+        when(matchMakingRepository.findFirstByIdNotAndMatchedGameCodeIsNullOrderByJoinedAtAsc(userId)).thenReturn(Optional.empty());
+
+        // when
+        matchMakingService.joinRandomGameSession(userId);
+
+        // then
+        verify(matchMakingRepository, times(1)).save(any(MatchMaking.class));
+        verify(matchMakingRepository, never()).delete(any());
+        verify(gameSessionService, never()).createGameSession(any());
+        verify(simpleMessagingTemplate, never()).convertAndSend(anyString(), (Object) any());
+    }
+
+    @Test
+    void joinRandomGameSession_PairsWithOpponent_AndDeletesEntriesAndSendsNotification() {
+        // given
+        Long userId = 1L;
+        Long opponentId = 2L;
+        MatchMaking myEntry = new MatchMaking();
+        myEntry.setId(userId);
+
+        MatchMaking opponentEntry = new MatchMaking();
+        opponentEntry.setId(opponentId);
+
+        when(matchMakingRepository.findById(userId)).thenReturn(Optional.empty());
+        User user = new User();
+        user.setId(userId);
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(matchMakingRepository.save(any(MatchMaking.class))).thenReturn(myEntry);
+
+        when(matchMakingRepository.findFirstByIdNotAndMatchedGameCodeIsNullOrderByJoinedAtAsc(userId))
+                .thenReturn(Optional.of(opponentEntry));
+
+        GameSession gameSession = new GameSession();
+        gameSession.setId(100L);
+        gameSession.setGameCode("XYZ123");
+
+        when(gameSessionService.createGameSession(any())).thenReturn(gameSession);
+
+        // when
+        matchMakingService.joinRandomGameSession(userId);
+
+        // then
+        verify(matchMakingRepository, atLeastOnce()).save(any(MatchMaking.class));
+        verify(matchMakingRepository, times(1)).delete(myEntry);
+        verify(matchMakingRepository, times(1)).delete(opponentEntry);
+        verify(simpleMessagingTemplate, times(1)).convertAndSend("/topic/match/" + userId, gameSession.getId());
+        verify(simpleMessagingTemplate, times(1)).convertAndSend("/topic/match/" + opponentId, gameSession.getId());
+        assertThat(myEntry.getMatchedGameCode()).isEqualTo(gameSession.getGameCode());
+        assertThat(opponentEntry.getMatchedGameCode()).isEqualTo(gameSession.getGameCode());
+    }
+
+    @Test
+    void leaveGameSession_RemovesEntry_IfExists() {
+        // given
+        Long userId = 10L;
+        MatchMaking entry = new MatchMaking();
+        entry.setId(userId);
+
+        when(matchMakingRepository.findById(userId)).thenReturn(Optional.of(entry));
+
+        // when
+        matchMakingService.leaveGameSession(userId);
+
+        // then
+        verify(matchMakingRepository).delete(entry);
+    }
+
+    @Test
+    void leaveGameSession_ThrowsException_IfUserNotFound() {
+        // given
+        Long userId = 42L;
+        when(matchMakingRepository.findById(userId)).thenReturn(Optional.empty());
+
+        // when
+        Throwable thrown = catchThrowable(() -> matchMakingService.leaveGameSession(userId));
+
+        // then
+        assertThat(thrown).isInstanceOf(ResponseStatusException.class);
+        assertThat(((ResponseStatusException)thrown).getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+    }
+
+    @Test
+    void joinRandomGameSession_UpdatesJoinedAt_IfAlreadyJoined() {
+        // given
+        Long userId = 555L;
+        MatchMaking entry = new MatchMaking();
+        entry.setId(userId);
+        entry.setJoinedAt(LocalDateTime.now().minusHours(1));
+        when(matchMakingRepository.findById(userId)).thenReturn(Optional.of(entry));
+        when(matchMakingRepository.save(any(MatchMaking.class))).thenReturn(entry);
+        when(matchMakingRepository.findFirstByIdNotAndMatchedGameCodeIsNullOrderByJoinedAtAsc(userId)).thenReturn(Optional.empty());
+
+        // when
+        matchMakingService.joinRandomGameSession(userId);
+
+        // then
+        verify(matchMakingRepository, times(1)).save(entry);
+    }
+
+    @Test
+    void purgeExpiredEntries_DeletesOldEntries() {
+        // given
+        // No setup necessary, just check correct repository call.
+
+        // when
+        matchMakingService.purgeExpiredEntries();
+
+        // then
+        verify(matchMakingRepository, times(1)).deleteByJoinedAtBeforeAndMatchedGameCodeIsNull(any(LocalDateTime.class));
+    }
+}
+


### PR DESCRIPTION
I made a new entity Matchmaking to save users who are searching for a game. Then the MatchMakingService automatically creates a GameSession once two players are queued. In the Matchmakingcontroller I created POST /matchmaking/join and DELETE /matchmaking/leave endpoints to enter and cancel the queue. I added a 60-second scheduled cleanup that removes unmatched players from the queue, updated the WebSocket flow so the game session's status switches once both players have joined, and broadcast the corresponding event to the client. Finally, I wrote unit tests covering the MatchMakingService logic and the matchmaking controller endpoints.