### PR TITLE
Harden matchmaking error paths and schema validation

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/exceptions/GlobalExceptionAdvice.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/exceptions/GlobalExceptionAdvice.java
@@ -40,4 +40,12 @@ public class GlobalExceptionAdvice extends ResponseEntityExceptionHandler {
 		log.error("Default Exception Handler -> caught:", ex);
 		return new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, ex.getMessage(), ex);
 	}
+
+	// Catch-all so unexpected exceptions (DataAccessException, MessagingException, NPE, ...)
+	// don't bypass our advice and produce a stack-trace-less 500.
+	@ExceptionHandler(Exception.class)
+	public ResponseEntity<Object> handleUncaughtException(Exception ex, WebRequest request) {
+		log.error("Unhandled exception on request {}", request.getDescription(false), ex);
+		return new ResponseEntity<>(ex.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
+	}
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/MatchMakingRepository.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/MatchMakingRepository.java
@@ -1,10 +1,12 @@
 package ch.uzh.ifi.hase.soprafs26.repository;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import ch.uzh.ifi.hase.soprafs26.entity.MatchMaking;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import java.util.List;
 import java.util.Optional;
 import java.time.LocalDateTime;
 
@@ -13,7 +15,14 @@ import java.time.LocalDateTime;
 @Repository("matchMakingRepository")
 public interface MatchMakingRepository extends JpaRepository<MatchMaking, Long> {
 
-    @Query("SELECT m FROM MatchMaking m WHERE m.id != :userId AND m.matchedGameCode IS NULL ORDER BY m.joinedAt ASC")
-    Optional<MatchMaking> findFirstByIdNotAndMatchedGameCodeIsNullOrderByJoinedAtAsc(@Param("userId") Long userId);
+    // @Query disables method-name-derived LIMIT, so we must page explicitly —
+    // returning Optional with >1 result throws IncorrectResultSizeDataAccessException.
+    @Query("SELECT m FROM MatchMaking m WHERE m.id <> :userId AND m.matchedGameCode IS NULL ORDER BY m.joinedAt ASC")
+    List<MatchMaking> findWaitingOpponents(@Param("userId") Long userId, Pageable pageable);
+
+    default Optional<MatchMaking> findFirstByIdNotAndMatchedGameCodeIsNullOrderByJoinedAtAsc(Long userId) {
+        return findWaitingOpponents(userId, Pageable.ofSize(1)).stream().findFirst();
+    }
+
     void deleteByJoinedAtBeforeAndMatchedGameCodeIsNull(LocalDateTime joinedAt);
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/MatchMakingService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/MatchMakingService.java
@@ -1,5 +1,7 @@
 package ch.uzh.ifi.hase.soprafs26.service;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -12,6 +14,7 @@ import java.time.LocalDateTime;
 import java.util.Optional;
 import ch.uzh.ifi.hase.soprafs26.entity.GameSession;
 import ch.uzh.ifi.hase.soprafs26.repository.GameSessionRepository;
+import org.springframework.messaging.MessagingException;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
 import ch.uzh.ifi.hase.soprafs26.service.GameSessionService;
@@ -20,6 +23,8 @@ import ch.uzh.ifi.hase.soprafs26.service.GameSessionService;
 @Service
 @Transactional
 public class MatchMakingService {
+
+    private static final Logger log = LoggerFactory.getLogger(MatchMakingService.class);
 
     private final MatchMakingRepository matchMakingRepository;
     private final UserRepository userRepository;
@@ -46,8 +51,8 @@ public class MatchMakingService {
             matchMakingRepository.save(myEntry);
             matchMakingRepository.save(opponent);
 
-            messagingTemplate.convertAndSend("/topic/match/" + userId, gameSession.getGameCode());
-            messagingTemplate.convertAndSend("/topic/match/" + opponent.getId(), gameSession.getGameCode());
+            notifyMatched(userId, gameSession.getGameCode());
+            notifyMatched(opponent.getId(), gameSession.getGameCode());
 
             matchMakingRepository.delete(myEntry);
             matchMakingRepository.delete(opponent);
@@ -78,6 +83,15 @@ public class MatchMakingService {
             return opponent.get();
         }
         return null;
+    }
+
+    private void notifyMatched(Long userId, String gameCode) {
+        try {
+            messagingTemplate.convertAndSend("/topic/match/" + userId, gameCode);
+        }
+        catch (MessagingException ex) {
+            log.warn("Failed to notify user {} of match {} over WebSocket: {}", userId, gameCode, ex.getMessage());
+        }
     }
 
     private GameSession createGameSession(Long userId1, Long userId2) {

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -5,5 +5,5 @@ spring.datasource.driver-class-name=org.postgresql.Driver
 spring.datasource.hikari.connection-timeout=10000
 spring.datasource.hikari.initialization-fail-timeout=10000
 spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
-spring.jpa.hibernate.ddl-auto=update
+spring.jpa.hibernate.ddl-auto=validate
 spring.h2.console.enabled=false


### PR DESCRIPTION
Today's prod 500 on /matchmaking/join had no stack trace in our logs because GlobalExceptionAdvice only caught HttpServerErrorException. The root cause was schema drift (game_sessions.current_turn_number missing) under ddl-auto=update silently skipping the failing NOT NULL ALTER. This commit closes those gaps and fixes two adjacent issues in the matchmaking flow.

- GlobalExceptionAdvice: catch-all @ExceptionHandler(Exception.class) that logs the stack trace, so unhandled exceptions stop producing blind 500s.
- MatchMakingRepository: the @Query annotation disabled the implicit LIMIT from the findFirst... method name, so more than one waiter caused IncorrectResultSizeDataAccessException. Use Pageable.ofSize(1) through a default method that keeps the original signature.
- MatchMakingService: extract notifyMatched() and swallow MessagingException with a warn log, so a STOMP delivery failure does not fail the HTTP join after the match is already persisted.
- application-prod.properties: ddl-auto update to validate, so the next schema drift fails loudly at startup instead of bleeding into runtime 500s.

NOTE on the validate flip: prod schema needs to be aligned with the entities before this is deployed, or the app will not boot. The current_turn_number column was added manually today; audit other recently-touched tables (match_making, leaderboard, etc.) before merging.